### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Async [![Build Status](https://api.travis-ci.com/apache/fineract-cn-async.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-async)
+# Apache Fineract CN Async
 
 This contains the code necessary for asynchronous execution of commands with the correct user permissions.
 


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.